### PR TITLE
pipeline: Support split control repos

### DIFF
--- a/manifests/pipeline.pp
+++ b/manifests/pipeline.pp
@@ -1,5 +1,7 @@
 define icinga_build::pipeline (
-  $control_repo,
+  $control_repo    = undef,
+  $control_rpm     = undef,
+  $control_deb     = undef,
   $ensure          = 'present',
   $product         = undef, # part of namevar
   $target          = undef, # part of namevar
@@ -24,12 +26,18 @@ define icinga_build::pipeline (
 ) {
   validate_re($ensure, '^(present|absent)$')
 
+  if $control_repo and ($control_rpm or $control_deb) {
+    fail('Can not mix control_repo with control_rpm/control_deb setting!')
+  } elsif !$control_repo and !$control_rpm and !$control_deb {
+    fail('You must configure control_repo or control_rpm/control_deb!')
+  }
+
   if $views_hash { validate_hash($views_hash) }
 
   if $product and $target {
     $_product = $product
     $_target = $target
-  } elsif $name =~ /^([\w\d\._]+)-([\w\d\._]+)$/ {
+  } elsif $name =~ /^([\w\d.\-_]+)-([\w\d._]+)$/ {
     $_product = $1
     $_target = $2
   } else {
@@ -87,6 +95,7 @@ define icinga_build::pipeline (
       ensure          => $ensure,
       product         => $_product,
       pipeline        => $title,
+      control_deb     => $control_deb,
       control_repo    => $control_repo,
       control_branch  => $control_branch,
       upstream_repo   => $upstream_repo,
@@ -110,6 +119,7 @@ define icinga_build::pipeline (
       ensure          => $ensure,
       product         => $_product,
       pipeline        => $title,
+      control_rpm     => $control_rpm,
       control_repo    => $control_repo,
       control_branch  => $control_branch,
       upstream_repo   => $upstream_repo,

--- a/manifests/pipeline/deb.pp
+++ b/manifests/pipeline/deb.pp
@@ -1,6 +1,7 @@
 define icinga_build::pipeline::deb (
   $pipeline,
   $product,
+  $control_deb,
   $control_repo,
   $control_branch,
   $release_type,

--- a/manifests/pipeline/rpm.pp
+++ b/manifests/pipeline/rpm.pp
@@ -1,6 +1,7 @@
 define icinga_build::pipeline::rpm (
   $pipeline,
   $product,
+  $control_rpm,
   $control_repo,
   $control_branch,
   $release_type,

--- a/spec/defines/pipeline/deb_spec.rb
+++ b/spec/defines/pipeline/deb_spec.rb
@@ -7,7 +7,7 @@ describe 'icinga_build::pipeline::deb' do
         facts
       end
 
-      context 'with a simple example' do
+      context 'with a split control repo' do
         let :title do
           'icinga2-snapshot-debian-jessie'
         end
@@ -27,7 +27,8 @@ describe 'icinga_build::pipeline::deb' do
           {
             product:         'icinga2',
             pipeline:        'icinga2-snapshot',
-            control_repo:    'https://github.com/Icinga/icinga-packaging.git',
+            control_repo:    :undef,
+            control_deb:     'https://github.com/Icinga/deb-icinga2.git',
             control_branch:  'snapshot',
             upstream_repo:   'https://github.com/Icinga/icinga2.git',
             upstream_branch: 'support/x.x',
@@ -44,7 +45,8 @@ describe 'icinga_build::pipeline::deb' do
 
         it do
           should contain_jenkins_job('icinga2-snapshot/deb-debian-jessie-0source')
-            .with_config(/#{Regexp.escape(params[:control_repo])}/)
+            .with_config(/<url>#{Regexp.escape(params[:control_deb])}<.url>/)
+            .with_config(/control_deb="#{Regexp.escape(params[:control_deb])}"/)
             .with_config(%r{BranchSpec.*\r?\n.*origin/support/x.x})
             .with_config(%r{<assignedNode>docker-test</assignedNode>})
             .with_config(%r{<image>private-registry:5000/icinga/debian-jessie-x86_64</image>})
@@ -77,6 +79,7 @@ describe 'icinga_build::pipeline::deb' do
           should contain_jenkins_job('icinga2-snapshot/deb-debian-jessie-2test')
             .with_config(/matrix-project/)
             .with_config(/project="icinga2"/)
+            .with_config(/control_deb="#{Regexp.escape(params[:control_deb])}"/)
             .with_config(%r{/start_test.sh})
         end
 
@@ -91,6 +94,70 @@ describe 'icinga_build::pipeline::deb' do
             .with_config(/dist="jessie"/)
             .with_config(/publish_type="deb"/)
             .without_config(/^arch=/)
+            .with_config(/curl_aptly/)
+        end
+      end
+
+      context 'with a old control repo' do
+        let :title do
+          'icinga2-snapshot-debian-jessie'
+        end
+
+        let :pre_condition do
+          "class { 'icinga_build::pipeline::defaults':
+            arch           => ['x86_64', 'x86'],
+            jenkins_label  => 'docker-test',
+            docker_image   => 'private-registry:5000/icinga/{os}-{dist}-{arch}',
+            aptly_server   => 'http://localhost',
+            aptly_user     => 'admin',
+            aptly_password => 'admin',
+          }"
+        end
+
+        let :params do
+          {
+            product:         'icinga2',
+            pipeline:        'icinga2-snapshot',
+            control_repo:    'https://github.com/Icinga/icinga-packaging.git',
+            control_deb:     :undef,
+            control_branch:  'snapshot',
+            upstream_repo:   'https://github.com/Icinga/icinga2.git',
+            upstream_branch: 'support/x.x',
+            release_type:    'snapshot'
+          }
+        end
+
+        it { should compile.with_all_deps }
+
+        # pre_condition
+        it { should contain_class('icinga_build::pipeline::defaults') }
+
+        it { should contain_icinga_build__pipeline__deb('icinga2-snapshot-debian-jessie') }
+
+        it do
+          should contain_jenkins_job('icinga2-snapshot/deb-debian-jessie-0source')
+            .with_config(/<url>#{Regexp.escape(params[:control_repo])}<.url>/)
+            .with_config(/control_deb=$/)
+            .with_config(/dpkg-buildpackage/)
+        end
+
+        it do
+          should contain_jenkins_job('icinga2-snapshot/deb-debian-jessie-1binary')
+            .with_config(/matrix-project/)
+            .with_config(/project="icinga2"/)
+            .with_config(/dpkg-buildpackage/)
+        end
+
+        it 'should have a test job' do
+          should contain_jenkins_job('icinga2-snapshot/deb-debian-jessie-2test')
+            .with_config(/matrix-project/)
+            .with_config(/project="icinga2"/)
+            .with_config(/control_deb=$/)
+            .with_config(%r{/start_test.sh})
+        end
+
+        it 'should have a publish job' do
+          should contain_jenkins_job('icinga2-snapshot/deb-debian-jessie-3-publish')
             .with_config(/curl_aptly/)
         end
       end

--- a/spec/defines/pipeline/rpm_spec.rb
+++ b/spec/defines/pipeline/rpm_spec.rb
@@ -18,7 +18,7 @@ describe 'icinga_build::pipeline::rpm' do
         }"
       end
 
-      context 'with a simple example' do
+      context 'with a split control repo' do
         let :title do
           'icinga2-snapshot-centos-7'
         end
@@ -27,7 +27,8 @@ describe 'icinga_build::pipeline::rpm' do
           {
             product:         'icinga2',
             pipeline:        'icinga2-snapshot',
-            control_repo:    'https://github.com/Icinga/icinga-packaging.git',
+            control_repo:    :undef,
+            control_rpm:     'https://github.com/Icinga/rpm-icinga2.git',
             control_branch:  'snapshot',
             upstream_repo:   'https://github.com/Icinga/icinga2.git',
             upstream_branch: 'support/x.x',
@@ -44,7 +45,8 @@ describe 'icinga_build::pipeline::rpm' do
 
         it do
           should contain_jenkins_job('icinga2-snapshot/rpm-centos-7-0source')
-            .with_config(/#{Regexp.escape(params[:control_repo])}/)
+            .with_config(/<url>#{Regexp.escape(params[:control_rpm])}<.url>/)
+            .with_config(/control_rpm="#{Regexp.escape(params[:control_rpm])}"/)
             .with_config(%r{BranchSpec.*\r?\n.*origin/support/x.x})
             .with_config(%r{<assignedNode>docker-test</assignedNode>})
             .with_config(%r{<image>private-registry:5000/icinga/centos-7-x86_64</image>})
@@ -76,6 +78,7 @@ describe 'icinga_build::pipeline::rpm' do
           should contain_jenkins_job('icinga2-snapshot/rpm-centos-7-2test')
             .with_config(/matrix-project/)
             .with_config(/project="icinga2"/)
+            .with_config(/control_rpm="#{Regexp.escape(params[:control_rpm])}"/)
             .with_config(%r{/start_test.sh})
         end
 
@@ -89,6 +92,60 @@ describe 'icinga_build::pipeline::rpm' do
             .with_config(/dist="7"/)
             .with_config(/publish_type="rpm"/)
             .without_config(/^arch=/)
+            .with_config(/curl_aptly/)
+        end
+      end
+
+      context 'with a old control repo' do
+        let :title do
+          'icinga2-snapshot-centos-7'
+        end
+
+        let :params do
+          {
+            product:         'icinga2',
+            pipeline:        'icinga2-snapshot',
+            control_repo:    'https://github.com/Icinga/icinga-packaging.git',
+            control_rpm:     :undef,
+            control_branch:  'snapshot',
+            upstream_repo:   'https://github.com/Icinga/icinga2.git',
+            upstream_branch: 'support/x.x',
+            release_type:    'snapshot'
+          }
+        end
+
+        it { should compile.with_all_deps }
+
+        # pre_condition
+        it { should contain_class('icinga_build::pipeline::defaults') }
+
+        it { should contain_icinga_build__pipeline__rpm('icinga2-snapshot-centos-7') }
+
+        it do
+          should contain_jenkins_job('icinga2-snapshot/rpm-centos-7-0source')
+            .with_config(/<url>#{Regexp.escape(params[:control_repo])}<.url>/)
+            .with_config(/control_rpm=$/)
+            .with_config(/rpmbuild --nodeps -bs/)
+            .with_config(/rpmbuild/)
+        end
+
+        it do
+          should contain_jenkins_job('icinga2-snapshot/rpm-centos-7-1binary')
+            .with_config(/matrix-project/)
+            .with_config(/project="icinga2"/)
+            .with_config(/rpmbuild --rebuild/)
+        end
+
+        it 'should have a test job' do
+          should contain_jenkins_job('icinga2-snapshot/rpm-centos-7-2test')
+            .with_config(/matrix-project/)
+            .with_config(/project="icinga2"/)
+            .with_config(/control_rpm=$/)
+            .with_config(%r{/start_test.sh})
+        end
+
+        it 'should have a publish job' do
+          should contain_jenkins_job('icinga2-snapshot/rpm-centos-7-3-publish')
             .with_config(/curl_aptly/)
         end
       end

--- a/spec/defines/pipeline_spec.rb
+++ b/spec/defines/pipeline_spec.rb
@@ -18,7 +18,7 @@ describe 'icinga_build::pipeline' do
         }"
       end
 
-      context 'with a simple example' do
+      context 'with a split control repos' do
         let :title do
           'icinga2-snapshot'
         end
@@ -26,13 +26,14 @@ describe 'icinga_build::pipeline' do
         let :params do
           {
             description:     'Test description with some text',
-            control_repo:    'https://github.com/Icinga/icinga-packaging.git',
-            control_branch:  'snapshot',
+            control_rpm:     'https://github.com/Icinga/rpm-icinga2.git',
+            control_deb:     'https://github.com/Icinga/deb-icinga2.git',
+            control_branch:  'master',
             upstream_repo:   'https://github.com/Icinga/icinga2.git',
             upstream_branch: 'support/x.x',
             matrix_deb:      {
-              'debian-jessie' => {},
-              'debian-wheezy' => {}
+              'debian-jessie'  => {},
+              'debian-stretch' => {},
             },
             matrix_rpm:      {
               'centos-6' => {},
@@ -41,12 +42,12 @@ describe 'icinga_build::pipeline' do
           }
         end
 
-        it { should compile.with_all_deps }
+        it {should compile.with_all_deps}
 
-        it { should contain_icinga_build__pipeline('icinga2-snapshot') }
+        it {should contain_icinga_build__pipeline('icinga2-snapshot')}
 
         # pre_condition
-        it { should contain_class('icinga_build::pipeline::defaults') }
+        it {should contain_class('icinga_build::pipeline::defaults')}
 
         it do
           should contain_icinga_build__folder('icinga2-snapshot')
@@ -61,7 +62,8 @@ describe 'icinga_build::pipeline' do
           should contain_icinga_build__pipeline__deb('icinga2-snapshot-debian-jessie')
             .with_product('icinga2')
             .with_pipeline('icinga2-snapshot')
-            .with_control_repo(params[:control_repo])
+            .with_control_repo(nil)
+            .with_control_deb(%r{/deb-})
             .with_control_branch(params[:control_branch])
             .with_jenkins_label('docker-test')
             .with_docker_image('private-registry:5000/icinga/{os}-{dist}-{arch}')
@@ -74,20 +76,21 @@ describe 'icinga_build::pipeline' do
         end
 
         it do
-          should contain_icinga_build__pipeline__deb('icinga2-snapshot-debian-wheezy')
+          should contain_icinga_build__pipeline__deb('icinga2-snapshot-debian-stretch')
 
           # for coverage
-          should contain_jenkins_job('icinga2-snapshot/deb-debian-wheezy-0source')
-          should contain_jenkins_job('icinga2-snapshot/deb-debian-wheezy-1binary')
-          should contain_jenkins_job('icinga2-snapshot/deb-debian-wheezy-2test')
-          should contain_jenkins_job('icinga2-snapshot/deb-debian-wheezy-3publish')
+          should contain_jenkins_job('icinga2-snapshot/deb-debian-stretch-0source')
+          should contain_jenkins_job('icinga2-snapshot/deb-debian-stretch-1binary')
+          should contain_jenkins_job('icinga2-snapshot/deb-debian-stretch-2test')
+          should contain_jenkins_job('icinga2-snapshot/deb-debian-stretch-3publish')
         end
 
         it do
           should contain_icinga_build__pipeline__rpm('icinga2-snapshot-centos-7')
             .with_product('icinga2')
             .with_pipeline('icinga2-snapshot')
-            .with_control_repo(params[:control_repo])
+            .with_control_repo(nil)
+            .with_control_rpm(%r{/rpm-})
             .with_control_branch(params[:control_branch])
             .with_jenkins_label('docker-test')
             .with_docker_image('private-registry:5000/icinga/{os}-{dist}-{arch}')
@@ -124,7 +127,8 @@ describe 'icinga_build::pipeline' do
         let :params do
           {
             description:    'Test description with some text',
-            control_repo:   'https://github.com/Icinga/icinga-packaging.git',
+            control_rpm:    'https://github.com/Icinga/rpm-icinga2.git',
+            control_deb:    'https://github.com/Icinga/deb-icinga2.git',
             control_branch: 'stable',
             product:        'icinga2',
             target:         'release',
@@ -160,12 +164,12 @@ describe 'icinga_build::pipeline' do
           }
         end
 
-        it { should compile.with_all_deps }
+        it {should compile.with_all_deps}
 
         # pre_condition
-        it { should contain_class('icinga_build::pipeline::defaults') }
+        it {should contain_class('icinga_build::pipeline::defaults')}
 
-        it { should contain_icinga_build__pipeline('icinga2') }
+        it {should contain_icinga_build__pipeline('icinga2')}
 
         it do
           should contain_icinga_build__folder('icinga2')
@@ -186,7 +190,8 @@ describe 'icinga_build::pipeline' do
             .with_product('icinga2')
             .with_pipeline('icinga2')
             .with_use('ubuntu')
-            .with_control_repo(params[:control_repo])
+            .with_control_repo(nil)
+            .with_control_deb(%r{/deb-})
             .with_control_branch(params[:control_branch])
             .with_jenkins_label('docker-test')
             .with_docker_image('private-registry:5000/icinga/{os}-{dist}-{arch}')
@@ -212,6 +217,53 @@ describe 'icinga_build::pipeline' do
 
         it do
           should contain_file('/var/lib/jenkins/aptly/icinga2-credentials').with_ensure(:absent)
+        end
+      end
+
+      context 'with a old control_repo logic' do
+        let :title do
+          'icinga2-snapshot'
+        end
+
+        let :params do
+          {
+            description:     'Test description with some text',
+            control_repo:    'https://github.com/Icinga/icinga-packaging.git',
+            control_branch:  'snapshot',
+            upstream_repo:   'https://github.com/Icinga/icinga2.git',
+            upstream_branch: 'support/x.x',
+            matrix_deb:      {
+              'debian-jessie' => {},
+              'debian-stretch' => {}
+            },
+            matrix_rpm:      {
+              'centos-6' => {},
+              'centos-7' => {}
+            }
+          }
+        end
+
+        it {should compile.with_all_deps}
+
+        it {should contain_icinga_build__pipeline('icinga2-snapshot')}
+
+        it do
+          should contain_icinga_build__pipeline__deb('icinga2-snapshot-debian-stretch')
+            .with_product('icinga2')
+            .with_pipeline('icinga2-snapshot')
+            .with_control_repo('https://github.com/Icinga/icinga-packaging.git')
+            .with_control_rpm(nil)
+            .with_control_deb(nil)
+            .with_control_branch(params[:control_branch])
+            .with_jenkins_label('docker-test')
+            .with_docker_image('private-registry:5000/icinga/{os}-{dist}-{arch}')
+
+          # for coverage
+          should contain_jenkins_job('icinga2-snapshot/deb-debian-stretch-0source')
+          should contain_jenkins_job('icinga2-snapshot/deb-debian-stretch-1binary')
+          should contain_jenkins_job('icinga2-snapshot/deb-debian-stretch-2test')
+          should contain_jenkins_job('icinga2-snapshot/deb-debian-stretch-3publish').with_ensure(:absent)
+          should contain_jenkins_job('icinga2-snapshot/deb-debian-stretch-3-publish')
         end
       end
     end

--- a/templates/jobs/deb_source.xml.erb
+++ b/templates/jobs/deb_source.xml.erb
@@ -42,7 +42,7 @@
     <configVersion>2</configVersion>
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>
-        <url><%= @control_repo.encode(xml: :text) %></url>
+        <url><%= (@control_deb || @control_repo).encode(xml: :text) %></url>
         <name>packaging</name>
       </hudson.plugins.git.UserRemoteConfig>
       <%- if @upstream_repo -%>
@@ -59,7 +59,7 @@
       </hudson.plugins.git.BranchSpec>
       <%- else -%>
       <hudson.plugins.git.BranchSpec>
-        <name>packaging/deb/<%= @control_branch.encode(xml: :text) %></name>
+        <name>packaging/<%= @control_deb.nil? ? 'deb/' : '' %><%= @control_branch.encode(xml: :text) %></name>
       </hudson.plugins.git.BranchSpec>
       <%- end -%>
     </branches>

--- a/templates/jobs/deb_test_matrix.xml.erb
+++ b/templates/jobs/deb_test_matrix.xml.erb
@@ -27,12 +27,12 @@
     <configVersion>2</configVersion>
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>
-        <url><%= @control_repo.encode(xml: :text) %></url>
+        <url><%= (@control_deb || @control_repo).encode(xml: :text) %></url>
       </hudson.plugins.git.UserRemoteConfig>
     </userRemoteConfigs>
     <branches>
       <hudson.plugins.git.BranchSpec>
-        <name>*/deb/<%= @control_branch.encode(xml: :text) %></name>
+        <name>*/<%= @control_deb.nil? ? 'deb/' : '' %><%= @control_branch.encode(xml: :text) %></name>
       </hudson.plugins.git.BranchSpec>
     </branches>
     <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>

--- a/templates/jobs/rpm_source.xml.erb
+++ b/templates/jobs/rpm_source.xml.erb
@@ -41,7 +41,7 @@
     <configVersion>2</configVersion>
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>
-        <url><%= @control_repo.encode(xml: :text) %></url>
+        <url><%= (@control_rpm || @control_repo).encode(xml: :text) %></url>
         <name>packaging</name>
       </hudson.plugins.git.UserRemoteConfig>
       <%- if @upstream_repo -%>
@@ -58,7 +58,7 @@
       </hudson.plugins.git.BranchSpec>
       <%- else -%>
       <hudson.plugins.git.BranchSpec>
-        <name>packaging/rpm/<%= @control_branch.encode(xml: :text) %></name>
+        <name>packaging/<%= @control_rpm.nil? ? 'rpm/' : '' %><%= @control_branch.encode(xml: :text) %></name>
       </hudson.plugins.git.BranchSpec>
       <%- end -%>
     </branches>

--- a/templates/jobs/rpm_test_matrix.xml.erb
+++ b/templates/jobs/rpm_test_matrix.xml.erb
@@ -27,12 +27,12 @@
     <configVersion>2</configVersion>
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>
-        <url><%= @control_repo.encode(xml: :text) %></url>
+        <url><%= (@control_rpm || @control_repo).encode(xml: :text) %></url>
       </hudson.plugins.git.UserRemoteConfig>
     </userRemoteConfigs>
     <branches>
       <hudson.plugins.git.BranchSpec>
-        <name>*/rpm/<%= @control_branch.encode(xml: :text) %></name>
+        <name>*/<%= @control_rpm.nil? ? 'rpm/' : '' %><%= @control_branch.encode(xml: :text) %></name>
       </hudson.plugins.git.BranchSpec>
     </branches>
     <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>

--- a/templates/scripts/deb_source.sh.erb
+++ b/templates/scripts/deb_source.sh.erb
@@ -8,6 +8,7 @@ os=<%= @_os.dump %>
 dist=<%= @_dist.dump %>
 use_dist=<%= @_use.dump %>
 release_type=<%= @release_type.dump %>
+control_deb=<%= @control_deb.dump unless @control_deb.nil? %>
 control_branch=<%= @control_branch.dump %>
 upstream_branch=<%= @upstream_branch.dump %>
 
@@ -24,13 +25,26 @@ rm -f *.version
 rm -f *.tar* *.dsc *.deb *.changes
 rm -rf "$project"
 
+if [ -n "$control_deb" ]; then
+  pkg_src=packaging
+else
+  pkg_src=packaging/${project}
+  control_branch="deb/$control_branch"
+fi
+
 if [ -n "$BUILD_BRANCH" ]; then
   upstream_branch="$BUILD_BRANCH"
   UPSTREAM_GIT_BRANCH=origin/"$upstream_branch"
 
-  # if this branch also exists in packaging deb/XX
-  if git --git-dir=packaging/.git/ rev-parse refs/remotes/packaging/deb/"$upstream_branch" &>/dev/null; then
-    control_branch="$upstream_branch"
+  if [ -n "$control_deb" ]; then
+    test_branch="$upstream_branch"
+  else
+    test_branch="deb/$upstream_branch"
+  fi
+
+  # if this branch also exists in packaging XX
+  if git --git-dir=packaging/.git/ rev-parse refs/remotes/packaging/"$test_branch" &>/dev/null; then
+    control_branch="$test_branch"
   fi
 elif [ -n "$BUILD_REF" ]; then
   upstream_branch="$BUILD_REF"
@@ -42,12 +56,13 @@ fi
 # ensure we checked out the packaging tree
 cd packaging/
 git clean -fxd
-git checkout -B deb/"$control_branch" packaging/deb/"$control_branch"
+git checkout -B "$control_branch" packaging/"$control_branch"
+GIT_PAGER=cat git show -s "$control_branch"
 cd ../
 
 # creating project directory
 mkdir "$project"
-cp -r packaging/${project}/${use_dist}/debian "$project"/
+cp -r ${pkg_src}/${use_dist}/debian "$project"/
 
 # download archive
 if [ "$release_type" == "release" ] ; then
@@ -58,7 +73,7 @@ else
   UPSTREAM_GIT_NOUPDATE=1 \
   UPSTREAM_GIT_NOREPO=1 \
   GIT_DIR=packaging/.git \
-    packaging/${project}/get_snapshot
+    ${pkg_src}/get_snapshot
 fi
 
 # figure out version

--- a/templates/scripts/deb_test.sh.erb
+++ b/templates/scripts/deb_test.sh.erb
@@ -3,5 +3,12 @@
 set -ex
 
 project=<%= @product.dump %>
+control_deb=<%= @control_deb.dump unless @control_deb.nil? %>
 
-./packaging/$project/testing/start_test.sh
+if [ -n "$control_deb" ]; then
+  pkg_src=./packaging
+else
+  pkg_src=./packaging/${project}
+fi
+
+"${pkg_src}"/testing/start_test.sh

--- a/templates/scripts/rpm_source.sh.erb
+++ b/templates/scripts/rpm_source.sh.erb
@@ -5,6 +5,7 @@ project=<%= @product.dump %>
 os=<%= @_os.dump %>
 dist=<%= @_dist.dump %>
 release_type=<%= @release_type.dump %>
+control_rpm=<%= @control_rpm.dump unless @control_rpm.nil? %>
 control_branch=<%= @control_branch.dump %>
 upstream_branch=<%= @upstream_branch.dump %>
 
@@ -21,13 +22,26 @@ set -ex
 
 <%= scope.function_template(['icinga_build/scripts/rpm_functions.sh.erb']) %>
 
+if [ -n "$control_rpm" ]; then
+  pkg_src=packaging
+else
+  pkg_src=packaging/${project}
+  control_branch="rpm/$control_branch"
+fi
+
 if [ -n "$BUILD_BRANCH" ]; then
   upstream_branch="$BUILD_BRANCH"
   UPSTREAM_GIT_BRANCH=origin/"$upstream_branch"
 
-  # if this branch also exists in packaging rpm/XX
-  if git --git-dir=packaging/.git/ rev-parse refs/remotes/packaging/rpm/"$upstream_branch" &>/dev/null; then
-    control_branch="$upstream_branch"
+  if [ -n "$control_rpm" ]; then
+    test_branch="$upstream_branch"
+  else
+    test_branch="rpm/$upstream_branch"
+  fi
+
+  # if this branch also exists in packaging XX
+  if git --git-dir=packaging/.git/ rev-parse refs/remotes/packaging/"$test_branch" &>/dev/null; then
+    control_branch="$test_branch"
   fi
 elif [ -n "$BUILD_REF" ]; then
   upstream_branch="$BUILD_REF"
@@ -39,12 +53,13 @@ fi
 # ensure we checked out the packaging tree
 cd packaging/
 git clean -fxd
-git branch -f rpm/"$control_branch" packaging/rpm/"$control_branch"
-git checkout -f rpm/"$control_branch"
+git branch -f "$control_branch" packaging/"$control_branch"
+git checkout -f "$control_branch"
+GIT_PAGER=cat git show -s "$control_branch"
 cd ../
 
-#this must not fail TODO: Something better, dirty hack
-cp -v packaging/${project}/* rpmbuild/SOURCES/ || true
+# copy to rpmbuild environment
+cp -rv ${pkg_src}/* rpmbuild/SOURCES/
 mv -v rpmbuild/SOURCES/*.spec rpmbuild/SPECS/
 
 # download archive
@@ -81,7 +96,7 @@ else
   UPSTREAM_GIT_NOUPDATE=1 \
   UPSTREAM_GIT_NOREPO=1 \
   GIT_DIR=packaging/.git \
-    packaging/${project}/get_snapshot
+    ${pkg_src}/get_snapshot
 
 	version=`cat ${project}.version | cut -f1`
 	revision="0.`date +%Y.%m.%d`+$BUILD_VERSION"

--- a/templates/scripts/rpm_test.sh.erb
+++ b/templates/scripts/rpm_test.sh.erb
@@ -5,6 +5,7 @@ set -ex
 project=<%= @product.dump %>
 os=<%= @_os.dump %>
 dist=<%= @_dist.dump %>
+control_rpm=<%= @control_rpm.dump unless @control_rpm.nil? %>
 
 # from job environment
 : ${arch:=x86_64}
@@ -15,6 +16,12 @@ if [ "$arch" = x86 ]; then
   target_arch=i386
 else
   target_arch="$arch"
+fi
+
+if [ -n "$control_rpm" ]; then
+  pkg_src=./packaging
+else
+  pkg_src=./packaging/${project}
 fi
 
 # Preparing local repository
@@ -96,4 +103,4 @@ install_package() {
   esac
 }
 
-source ./packaging/"$project"/testing/start_test.sh
+source "${pkg_src}"/testing/start_test.sh


### PR DESCRIPTION
Example how this is configured:

```yaml
  icinga2-templates-snapshot:
    control_deb: https://github.com/Icinga/deb-icinga2-templates.git
    control_rpm: https://github.com/Icinga/rpm-icinga2-templates.git
    control_branch: master
    upstream_repo: https://github.com/Icinga/icinga-template-library.git
    release_type: snapshot
    arch:
      - x86_64
    matrix_deb:
      <<: *icinga2_templates_matrix_deb
    matrix_rpm:
      <<: *icinga2_templates_matrix_rpm
```

- [x] Testing new mode
- [x] Testing old mode